### PR TITLE
feat: Invoice Model & Core CRUD API (/invoices)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,23 +70,31 @@ model MerchantSession {
 }
 
 enum Status {
+  DRAFT
   PENDING
   PAID
   CANCELLED
 }
 
 model Invoice {
-  id        String   @id @default(uuid())
-  invoiceId Int      @unique
-  amount    BigInt
-  token     String
-  merchantId String
-  merchant  Merchant @relation(fields: [merchantId], references: [id])
-  ref       String
-  payer     String?
-  email     String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  status    Status
-  datePaid  DateTime?
+  id          String    @id @default(uuid())
+  invoiceId   Int?      @unique
+  paymentSlug String    @unique
+  description String
+  amount      BigInt
+  token       String
+  merchantId  String
+  merchant    Merchant  @relation(fields: [merchantId], references: [id])
+  status      Status    @default(PENDING)
+  ref         String?
+  payer       String?
+  payerEmail  String?
+  email       String?
+  expiresAt   DateTime?
+  datePaid    DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([merchantId])
+  @@index([merchantId, status])
 }

--- a/src/controllers/invoice.controllers.ts
+++ b/src/controllers/invoice.controllers.ts
@@ -1,0 +1,95 @@
+import { Request, Response } from 'express';
+import {
+  createInvoice,
+  getInvoice,
+  listInvoices,
+  voidInvoice,
+} from '../services/invoice.services.js';
+import { parseInvoiceListQuery, validateCreateInvoice } from '../utils/invoice.validation.js';
+import { AppError } from '../utils/errors.js';
+
+export const createInvoiceController = async (req: Request, res: Response): Promise<void> => {
+  const merchant = req.merchant;
+  if (!merchant) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const errors = validateCreateInvoice(req.body);
+  if (Object.keys(errors).length > 0) {
+    res.status(400).json({ error: 'Validation failed', errors });
+    return;
+  }
+
+  try {
+    const invoice = await createInvoice(merchant.id, req.body);
+    res.status(201).json(invoice);
+  } catch (error) {
+    if (error instanceof AppError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export const listInvoicesController = async (req: Request, res: Response): Promise<void> => {
+  const merchant = req.merchant;
+  if (!merchant) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const { filters, pagination, errors } = parseInvoiceListQuery(
+    req.query as Record<string, unknown>,
+  );
+  if (Object.keys(errors).length > 0) {
+    res.status(400).json({ error: 'Validation failed', errors });
+    return;
+  }
+
+  try {
+    const result = await listInvoices(merchant.id, filters, pagination);
+    res.status(200).json(result);
+  } catch {
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export const getInvoiceController = async (req: Request, res: Response): Promise<void> => {
+  const merchant = req.merchant;
+  if (!merchant) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const invoice = await getInvoice(merchant.id, req.params.id);
+    res.status(200).json(invoice);
+  } catch (error) {
+    if (error instanceof AppError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export const voidInvoiceController = async (req: Request, res: Response): Promise<void> => {
+  const merchant = req.merchant;
+  if (!merchant) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const invoice = await voidInvoice(merchant.id, req.params.id);
+    res.status(200).json(invoice);
+  } catch (error) {
+    if (error instanceof AppError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,10 +1,12 @@
 import merchantRoutes from './merchant.routes.js';
 import authRoutes from './auth.routes.js';
+import invoiceRoutes from './invoice.routes.js';
 import { Router } from 'express';
 
 const router = Router();
 
 router.use('/merchants', merchantRoutes);
 router.use('/auth', authRoutes);
+router.use('/invoices', invoiceRoutes);
 
 export default router;

--- a/src/routes/invoice.routes.ts
+++ b/src/routes/invoice.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import {
+  createInvoiceController,
+  getInvoiceController,
+  listInvoicesController,
+  voidInvoiceController,
+} from '../controllers/invoice.controllers.js';
+import { authenticateMerchant } from '../middlewares/auth.middleware.js';
+
+const router = Router();
+
+router.use(authenticateMerchant);
+
+router.post('/', createInvoiceController);
+router.get('/', listInvoicesController);
+router.get('/:id', getInvoiceController);
+router.patch('/:id/void', voidInvoiceController);
+
+export default router;

--- a/src/services/invoice.services.ts
+++ b/src/services/invoice.services.ts
@@ -1,0 +1,156 @@
+import type { Invoice, Prisma, Status } from '@prisma/client';
+import prisma from '../config/prisma.js';
+import { AppError } from '../utils/errors.js';
+import { generatePaymentSlug } from '../utils/slug.js';
+import {
+  CreateInvoiceInput,
+  InvoiceListFilters,
+  InvoicePagination,
+  parseAmount,
+} from '../utils/invoice.validation.js';
+
+const SLUG_MAX_RETRIES = 5;
+
+// String constants matching the Prisma `Status` enum. Defined locally so this
+// module never imports a runtime value from `@prisma/client` (the generated
+// client is mocked in tests and not generated in CI).
+const InvoiceStatus = {
+  DRAFT: 'DRAFT',
+  PENDING: 'PENDING',
+  PAID: 'PAID',
+  CANCELLED: 'CANCELLED',
+} as const satisfies Record<string, Status>;
+
+/**
+ * Public-facing view of an invoice. `amount` is serialized to a string because
+ * `BigInt` is not JSON-serializable.
+ */
+export const sanitizeInvoice = (invoice: Invoice) => ({
+  id: invoice.id,
+  paymentSlug: invoice.paymentSlug,
+  description: invoice.description,
+  amount: invoice.amount.toString(),
+  token: invoice.token,
+  status: invoice.status,
+  merchantId: invoice.merchantId,
+  payerEmail: invoice.payerEmail,
+  expiresAt: invoice.expiresAt,
+  datePaid: invoice.datePaid,
+  createdAt: invoice.createdAt,
+  updatedAt: invoice.updatedAt,
+});
+
+const isUniqueSlugError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) return false;
+  const { code, meta } = error as { code?: string; meta?: { target?: unknown } };
+  return code === 'P2002' && Array.isArray(meta?.target) && meta.target.includes('paymentSlug');
+};
+
+export const createInvoice = async (merchantId: string, data: CreateInvoiceInput) => {
+  const amount = parseAmount(data.amount);
+  if (amount === null) {
+    throw new AppError(400, 'amount must be a positive integer');
+  }
+
+  const status: Status = data.isDraft ? InvoiceStatus.DRAFT : InvoiceStatus.PENDING;
+  const expiresAt = data.expiresAt ? new Date(data.expiresAt) : null;
+
+  for (let attempt = 0; attempt < SLUG_MAX_RETRIES; attempt++) {
+    try {
+      const invoice = await prisma.invoice.create({
+        data: {
+          merchantId,
+          description: data.description.trim(),
+          amount,
+          token: data.token.trim(),
+          payerEmail: data.payerEmail?.trim() ?? null,
+          expiresAt,
+          status,
+          paymentSlug: generatePaymentSlug(),
+        },
+      });
+      return sanitizeInvoice(invoice);
+    } catch (error) {
+      if (isUniqueSlugError(error) && attempt < SLUG_MAX_RETRIES - 1) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new AppError(500, 'Failed to generate a unique payment slug');
+};
+
+export const listInvoices = async (
+  merchantId: string,
+  filters: InvoiceListFilters,
+  pagination: InvoicePagination,
+) => {
+  const where: Prisma.InvoiceWhereInput = { merchantId };
+
+  if (filters.status) {
+    where.status = filters.status;
+  }
+
+  if (filters.token) {
+    where.token = filters.token;
+  }
+
+  if (filters.startDate || filters.endDate) {
+    where.createdAt = {};
+    if (filters.startDate) where.createdAt.gte = filters.startDate;
+    if (filters.endDate) where.createdAt.lte = filters.endDate;
+  }
+
+  const [invoices, total] = await Promise.all([
+    prisma.invoice.findMany({
+      where,
+      take: pagination.limit,
+      skip: pagination.offset,
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.invoice.count({ where }),
+  ]);
+
+  return {
+    data: invoices.map(sanitizeInvoice),
+    pagination: {
+      limit: pagination.limit,
+      offset: pagination.offset,
+      total,
+    },
+  };
+};
+
+export const getInvoice = async (merchantId: string, id: string) => {
+  const invoice = await prisma.invoice.findFirst({
+    where: { id, merchantId },
+  });
+
+  if (!invoice) {
+    throw new AppError(404, 'Invoice not found');
+  }
+
+  return sanitizeInvoice(invoice);
+};
+
+export const voidInvoice = async (merchantId: string, id: string) => {
+  const invoice = await prisma.invoice.findFirst({
+    where: { id, merchantId },
+  });
+
+  if (!invoice) {
+    throw new AppError(404, 'Invoice not found');
+  }
+
+  if (invoice.status !== InvoiceStatus.PENDING) {
+    throw new AppError(400, 'Only pending invoices can be voided');
+  }
+
+  const updated = await prisma.invoice.update({
+    where: { id: invoice.id },
+    data: { status: InvoiceStatus.CANCELLED },
+  });
+
+  return sanitizeInvoice(updated);
+};

--- a/src/utils/invoice.validation.ts
+++ b/src/utils/invoice.validation.ts
@@ -1,0 +1,170 @@
+import type { Status } from '@prisma/client';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const POSITIVE_INTEGER_REGEX = /^\d+$/;
+
+// String constants matching the Prisma `Status` enum. Defined locally so this
+// module never imports a runtime value from `@prisma/client` (the generated
+// client is mocked in tests and not generated in CI).
+const INVOICE_STATUSES = [
+  'DRAFT',
+  'PENDING',
+  'PAID',
+  'CANCELLED',
+] as const satisfies readonly Status[];
+
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+export interface CreateInvoiceInput {
+  description: string;
+  amount: string | number;
+  token: string;
+  payerEmail?: string;
+  expiresAt?: string;
+  isDraft?: boolean;
+}
+
+export interface InvoiceListFilters {
+  status?: Status;
+  token?: string;
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export interface InvoicePagination {
+  limit: number;
+  offset: number;
+}
+
+export type ValidationErrors = Record<string, string>;
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+/**
+ * Parses and validates a positive integer amount supplied as a number or a
+ * numeric string. Returns the BigInt value, or null when invalid.
+ */
+export const parseAmount = (value: unknown): bigint | null => {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value <= 0) return null;
+    return BigInt(value);
+  }
+
+  if (typeof value === 'string' && POSITIVE_INTEGER_REGEX.test(value.trim())) {
+    const parsed = BigInt(value.trim());
+    return parsed > 0n ? parsed : null;
+  }
+
+  return null;
+};
+
+export const validateCreateInvoice = (body: unknown): ValidationErrors => {
+  const errors: ValidationErrors = {};
+  const payload = (body ?? {}) as Record<string, unknown>;
+
+  if (!isNonEmptyString(payload.description)) {
+    errors.description = 'description is required';
+  }
+
+  if (parseAmount(payload.amount) === null) {
+    errors.amount = 'amount must be a positive integer';
+  }
+
+  if (!isNonEmptyString(payload.token)) {
+    errors.token = 'token must be a non-empty string';
+  }
+
+  if (
+    payload.payerEmail !== undefined &&
+    payload.payerEmail !== null &&
+    !(
+      isNonEmptyString(payload.payerEmail) &&
+      EMAIL_REGEX.test((payload.payerEmail as string).trim())
+    )
+  ) {
+    errors.payerEmail = 'payerEmail must be a valid email';
+  }
+
+  if (payload.expiresAt !== undefined && payload.expiresAt !== null) {
+    const date = new Date(payload.expiresAt as string);
+    if (Number.isNaN(date.getTime())) {
+      errors.expiresAt = 'expiresAt must be a valid date';
+    }
+  }
+
+  if (payload.isDraft !== undefined && typeof payload.isDraft !== 'boolean') {
+    errors.isDraft = 'isDraft must be a boolean';
+  }
+
+  return errors;
+};
+
+export interface ParsedListQuery {
+  filters: InvoiceListFilters;
+  pagination: InvoicePagination;
+  errors: ValidationErrors;
+}
+
+/**
+ * Parses list query parameters into typed filters and pagination, clamping the
+ * page size to [1, MAX_LIMIT] and defaulting to DEFAULT_LIMIT.
+ */
+export const parseInvoiceListQuery = (query: Record<string, unknown>): ParsedListQuery => {
+  const errors: ValidationErrors = {};
+  const filters: InvoiceListFilters = {};
+
+  if (query.status !== undefined) {
+    const status = String(query.status).toUpperCase();
+    if ((INVOICE_STATUSES as readonly string[]).includes(status)) {
+      filters.status = status as Status;
+    } else {
+      errors.status = `status must be one of ${INVOICE_STATUSES.join(', ')}`;
+    }
+  }
+
+  if (isNonEmptyString(query.token)) {
+    filters.token = query.token.trim();
+  }
+
+  if (query.startDate !== undefined) {
+    const date = new Date(String(query.startDate));
+    if (Number.isNaN(date.getTime())) {
+      errors.startDate = 'startDate must be a valid date';
+    } else {
+      filters.startDate = date;
+    }
+  }
+
+  if (query.endDate !== undefined) {
+    const date = new Date(String(query.endDate));
+    if (Number.isNaN(date.getTime())) {
+      errors.endDate = 'endDate must be a valid date';
+    } else {
+      filters.endDate = date;
+    }
+  }
+
+  let limit = DEFAULT_LIMIT;
+  if (query.limit !== undefined) {
+    const parsed = Number(query.limit);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      errors.limit = 'limit must be a positive number';
+    } else {
+      limit = Math.min(Math.floor(parsed), MAX_LIMIT);
+    }
+  }
+
+  let offset = 0;
+  if (query.offset !== undefined) {
+    const parsed = Number(query.offset);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      errors.offset = 'offset must be a non-negative number';
+    } else {
+      offset = Math.floor(parsed);
+    }
+  }
+
+  return { filters, pagination: { limit, offset }, errors };
+};

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,10 @@
+import { randomBytes } from 'crypto';
+
+/**
+ * Generates a url-safe, collision-resistant payment slug.
+ *
+ * Uses base64url encoding (characters A-Z, a-z, 0-9, `-`, `_`) so the slug can
+ * be embedded directly in a payment URL without escaping. 12 random bytes yield
+ * 16 characters and ~96 bits of entropy.
+ */
+export const generatePaymentSlug = (): string => randomBytes(12).toString('base64url');

--- a/tests/integration/invoice.routes.test.ts
+++ b/tests/integration/invoice.routes.test.ts
@@ -1,0 +1,194 @@
+import { mockReset } from 'jest-mock-extended';
+import request from 'supertest';
+
+const { default: prismaMock } = (await import('../../src/config/prisma.js')) as any;
+const { default: app } = await import('../../src/app.js');
+
+const MERCHANT_ID = 'merchant-1';
+
+const merchant = {
+  id: MERCHANT_ID,
+  merchantId: 1,
+  email: 'merchant@example.com',
+  address: '0x123',
+  registered: true,
+};
+
+const baseInvoice = {
+  id: 'invoice-1',
+  invoiceId: null,
+  paymentSlug: 'aZ09-_slug',
+  description: 'Website design',
+  amount: 5000n,
+  token: 'USDC',
+  merchantId: MERCHANT_ID,
+  status: 'PENDING',
+  ref: null,
+  payer: null,
+  payerEmail: null,
+  email: null,
+  expiresAt: null,
+  datePaid: null,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const authenticate = () => {
+  prismaMock.merchantSession.findUnique.mockResolvedValue({
+    id: 'session-1',
+    merchantId: MERCHANT_ID,
+    token: 'valid-token',
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    createdAt: new Date(),
+    merchant,
+  } as any);
+};
+
+const auth = { Authorization: 'Bearer valid-token' };
+
+describe('Invoice routes', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  describe('POST /api/v1/invoices', () => {
+    test('returns 401 when unauthenticated', async () => {
+      const response = await request(app)
+        .post('/api/v1/invoices')
+        .send({ description: 'x', amount: '100', token: 'USDC' });
+
+      expect(response.status).toBe(401);
+      expect(prismaMock.invoice.create).not.toHaveBeenCalled();
+    });
+
+    test('returns 201 with a unique url-safe paymentSlug', async () => {
+      authenticate();
+      prismaMock.invoice.create.mockImplementation(async (args: any) => ({
+        ...baseInvoice,
+        ...args.data,
+      }));
+
+      const response = await request(app)
+        .post('/api/v1/invoices')
+        .set(auth)
+        .send({ description: 'Website design', amount: '5000', token: 'USDC' });
+
+      expect(response.status).toBe(201);
+      expect(response.body.status).toBe('PENDING');
+      expect(response.body.amount).toBe('5000');
+      expect(response.body.paymentSlug).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    test('creates a DRAFT invoice when isDraft is true', async () => {
+      authenticate();
+      prismaMock.invoice.create.mockImplementation(async (args: any) => ({
+        ...baseInvoice,
+        ...args.data,
+      }));
+
+      const response = await request(app)
+        .post('/api/v1/invoices')
+        .set(auth)
+        .send({ description: 'Draft', amount: '5000', token: 'USDC', isDraft: true });
+
+      expect(response.status).toBe(201);
+      expect(response.body.status).toBe('DRAFT');
+    });
+
+    test('returns 400 when amount is not positive or token is empty', async () => {
+      authenticate();
+
+      const response = await request(app)
+        .post('/api/v1/invoices')
+        .set(auth)
+        .send({ description: 'x', amount: -5, token: '' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errors).toMatchObject({
+        amount: expect.any(String),
+        token: expect.any(String),
+      });
+      expect(prismaMock.invoice.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /api/v1/invoices', () => {
+    test('returns a paginated list scoped to the merchant with status filter', async () => {
+      authenticate();
+      prismaMock.invoice.findMany.mockResolvedValue([baseInvoice] as any);
+      prismaMock.invoice.count.mockResolvedValue(1 as any);
+
+      const response = await request(app)
+        .get('/api/v1/invoices?status=PENDING&limit=10&offset=0')
+        .set(auth);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.pagination).toEqual({ limit: 10, offset: 0, total: 1 });
+
+      const findArgs = prismaMock.invoice.findMany.mock.calls[0][0];
+      expect(findArgs.where).toMatchObject({ merchantId: MERCHANT_ID, status: 'PENDING' });
+    });
+
+    test('clamps limit to the maximum of 100', async () => {
+      authenticate();
+      prismaMock.invoice.findMany.mockResolvedValue([] as any);
+      prismaMock.invoice.count.mockResolvedValue(0 as any);
+
+      const response = await request(app).get('/api/v1/invoices?limit=500').set(auth);
+
+      expect(response.status).toBe(200);
+      expect(response.body.pagination.limit).toBe(100);
+    });
+  });
+
+  describe('GET /api/v1/invoices/:id', () => {
+    test('returns 200 when the invoice belongs to the merchant', async () => {
+      authenticate();
+      prismaMock.invoice.findFirst.mockResolvedValue(baseInvoice as any);
+
+      const response = await request(app).get('/api/v1/invoices/invoice-1').set(auth);
+
+      expect(response.status).toBe(200);
+      expect(response.body.id).toBe('invoice-1');
+    });
+
+    test('returns 404 when the invoice is missing or owned by another merchant', async () => {
+      authenticate();
+      prismaMock.invoice.findFirst.mockResolvedValue(null);
+
+      const response = await request(app).get('/api/v1/invoices/other').set(auth);
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('PATCH /api/v1/invoices/:id/void', () => {
+    test('voids a PENDING invoice', async () => {
+      authenticate();
+      prismaMock.invoice.findFirst.mockResolvedValue(baseInvoice as any);
+      prismaMock.invoice.update.mockResolvedValue({
+        ...baseInvoice,
+        status: 'CANCELLED',
+      } as any);
+
+      const response = await request(app).patch('/api/v1/invoices/invoice-1/void').set(auth);
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('CANCELLED');
+    });
+
+    test('returns 400 when voiding a non-PENDING invoice', async () => {
+      authenticate();
+      prismaMock.invoice.findFirst.mockResolvedValue({
+        ...baseInvoice,
+        status: 'PAID',
+      } as any);
+
+      const response = await request(app).patch('/api/v1/invoices/invoice-1/void').set(auth);
+
+      expect(response.status).toBe(400);
+      expect(prismaMock.invoice.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/invoice.services.test.ts
+++ b/tests/unit/invoice.services.test.ts
@@ -1,0 +1,161 @@
+import { mockReset } from 'jest-mock-extended';
+
+const { default: prismaMock } = (await import('../../src/config/prisma.js')) as any;
+const { createInvoice, listInvoices, getInvoice, voidInvoice } = await import(
+  '../../src/services/invoice.services.js'
+);
+
+const MERCHANT_ID = 'merchant-1';
+
+const baseInvoice = {
+  id: 'invoice-1',
+  invoiceId: null,
+  paymentSlug: 'slug-1',
+  description: 'Website design',
+  amount: 5000n,
+  token: 'USDC',
+  merchantId: MERCHANT_ID,
+  status: 'PENDING',
+  ref: null,
+  payer: null,
+  payerEmail: null,
+  email: null,
+  expiresAt: null,
+  datePaid: null,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+describe('invoice services', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  describe('createInvoice', () => {
+    test('creates a PENDING invoice with a generated url-safe slug', async () => {
+      prismaMock.invoice.create.mockImplementation(async (args: any) => ({
+        ...baseInvoice,
+        ...args.data,
+      }));
+
+      const result = await createInvoice(MERCHANT_ID, {
+        description: 'Website design',
+        amount: '5000',
+        token: 'USDC',
+      });
+
+      expect(result.status).toBe('PENDING');
+      expect(result.amount).toBe('5000');
+      expect(typeof result.paymentSlug).toBe('string');
+      expect(result.paymentSlug).toMatch(/^[A-Za-z0-9_-]+$/);
+
+      const createArgs = prismaMock.invoice.create.mock.calls[0][0];
+      expect(createArgs.data.amount).toBe(5000n);
+      expect(createArgs.data.merchantId).toBe(MERCHANT_ID);
+    });
+
+    test('creates a DRAFT invoice when isDraft is true', async () => {
+      prismaMock.invoice.create.mockImplementation(async (args: any) => ({
+        ...baseInvoice,
+        ...args.data,
+      }));
+
+      const result = await createInvoice(MERCHANT_ID, {
+        description: 'Draft job',
+        amount: 100,
+        token: 'XLM',
+        isDraft: true,
+      });
+
+      expect(result.status).toBe('DRAFT');
+    });
+
+    test('rejects a non-positive amount with a 400', async () => {
+      await expect(
+        createInvoice(MERCHANT_ID, { description: 'x', amount: 0, token: 'USDC' }),
+      ).rejects.toMatchObject({ statusCode: 400 });
+      expect(prismaMock.invoice.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listInvoices', () => {
+    test('scopes results to the merchant and returns pagination metadata', async () => {
+      prismaMock.invoice.findMany.mockResolvedValue([baseInvoice] as any);
+      prismaMock.invoice.count.mockResolvedValue(1 as any);
+
+      const result = await listInvoices(
+        MERCHANT_ID,
+        { status: 'PENDING' as any },
+        { limit: 20, offset: 0 },
+      );
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].amount).toBe('5000');
+      expect(result.pagination).toEqual({ limit: 20, offset: 0, total: 1 });
+
+      const findArgs = prismaMock.invoice.findMany.mock.calls[0][0];
+      expect(findArgs.where).toMatchObject({ merchantId: MERCHANT_ID, status: 'PENDING' });
+      expect(findArgs.take).toBe(20);
+      expect(findArgs.skip).toBe(0);
+    });
+  });
+
+  describe('getInvoice', () => {
+    test('returns the invoice when it belongs to the merchant', async () => {
+      prismaMock.invoice.findFirst.mockResolvedValue(baseInvoice as any);
+
+      const result = await getInvoice(MERCHANT_ID, 'invoice-1');
+
+      expect(result.id).toBe('invoice-1');
+      expect(prismaMock.invoice.findFirst).toHaveBeenCalledWith({
+        where: { id: 'invoice-1', merchantId: MERCHANT_ID },
+      });
+    });
+
+    test('throws 404 when the invoice is missing or owned by another merchant', async () => {
+      prismaMock.invoice.findFirst.mockResolvedValue(null);
+
+      await expect(getInvoice(MERCHANT_ID, 'missing')).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe('voidInvoice', () => {
+    test('voids a PENDING invoice and sets status CANCELLED', async () => {
+      prismaMock.invoice.findFirst.mockResolvedValue(baseInvoice as any);
+      prismaMock.invoice.update.mockResolvedValue({
+        ...baseInvoice,
+        status: 'CANCELLED',
+      } as any);
+
+      const result = await voidInvoice(MERCHANT_ID, 'invoice-1');
+
+      expect(result.status).toBe('CANCELLED');
+      expect(prismaMock.invoice.update).toHaveBeenCalledWith({
+        where: { id: 'invoice-1' },
+        data: { status: 'CANCELLED' },
+      });
+    });
+
+    test('throws 400 when voiding a non-PENDING invoice', async () => {
+      prismaMock.invoice.findFirst.mockResolvedValue({
+        ...baseInvoice,
+        status: 'PAID',
+      } as any);
+
+      await expect(voidInvoice(MERCHANT_ID, 'invoice-1')).rejects.toMatchObject({
+        statusCode: 400,
+      });
+      expect(prismaMock.invoice.update).not.toHaveBeenCalled();
+    });
+
+    test('throws 404 when the invoice does not belong to the merchant', async () => {
+      prismaMock.invoice.findFirst.mockResolvedValue(null);
+
+      await expect(voidInvoice(MERCHANT_ID, 'invoice-1')).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the invoice model expansion and merchant-facing CRUD described in #12: create, list, get, and void — all protected and scoped to the authenticated merchant.

> [!NOTE]
> Rebased onto the latest `main` (now includes the merged merchant-auth work from #16 and the auth-verify endpoint from #15). No conflicts; the diff is limited to invoice files.

## Endpoints

All routes live under `/api/v1/invoices` and require a valid merchant session (`Authorization: Bearer <token>`).

| Method | Path | Description |
| --- | --- | --- |
| `POST` | `/invoices` | Create an invoice |
| `GET` | `/invoices` | List invoices (filtered, paginated) |
| `GET` | `/invoices/:id` | Get one invoice by UUID |
| `PATCH` | `/invoices/:id/void` | Void a `PENDING` invoice |

### Create

Accepts `description`, `amount`, `token`, and optional `payerEmail`, `expiresAt`, `isDraft`. A unique, url-safe `paymentSlug` (base64url) is generated server-side. Status is `DRAFT` when `isDraft: true`, otherwise `PENDING`.

### List

Query filters: `status`, `token`, `startDate`, `endDate`. Pagination: `limit` (default 20, clamped to max 100) and `offset`. Returns `{ data, pagination: { limit, offset, total } }`, scoped to the authenticated merchant and ordered newest-first.

## Changes

- **Schema** (`prisma/schema.prisma`): adds `DRAFT` to the `Status` enum and expands `Invoice` with `paymentSlug` (`@unique`), `description`, `payerEmail`, `expiresAt`, a `status` default of `PENDING`, makes `invoiceId`/`ref` optional, and indexes `merchantId` / `(merchantId, status)`.
- **Services** (`src/services/invoice.services.ts`): `createInvoice`, `listInvoices`, `getInvoice`, `voidInvoice`. Ownership is enforced via `merchantId` on every query. `sanitizeInvoice` serializes the `BigInt` amount to a string (JSON-safe). Slug creation retries on the rare unique-constraint collision.
- **Validation** (`src/utils/invoice.validation.ts`): positive-integer amount parsing, non-empty token, optional email/date checks, and list-query parsing with limit clamping.
- **Slug** (`src/utils/slug.ts`): base64url payment slug generator (~96 bits of entropy).
- **Controllers / routes** (`src/controllers/invoice.controllers.ts`, `src/routes/invoice.routes.ts`): wired under `/invoices` behind `authenticateMerchant` and mounted in `src/routes/index.ts`.

> [!IMPORTANT]
> `@prisma/client` is imported **type-only** throughout the invoice modules (enum/status handled via local string constants, Prisma error detection via duck-typing on `code === 'P2002'`). This keeps the test runtime free of the generated client — consistent with the project's fully-mocked Jest setup, where CI does not run `prisma generate`.

## Acceptance criteria

- [x] `POST /invoices` returns `201` with the created invoice including `paymentSlug`
- [x] `paymentSlug` is unique and url-safe
- [x] `isDraft: true` creates an invoice with `status = DRAFT`
- [x] `GET /invoices` returns a paginated list scoped to the authenticated merchant
- [x] Status filter works correctly
- [x] `GET /invoices/:id` returns `404` when the invoice doesn't exist or belongs to another merchant
- [x] `PATCH /invoices/:id/void` on a non-`PENDING` invoice → `400`
- [x] Amount must be positive; token must be a non-empty string

## Test plan

- `npm test` — full suite green (8 suites, including the merchant/auth suites already on `main` and the new invoice suites). New tests: `tests/unit/invoice.services.test.ts` and `tests/integration/invoice.routes.test.ts` cover each acceptance criterion (auth, create PENDING/DRAFT, validation, scoped list + filter + limit clamping, 404 ownership, void rules).
- Verified the invoice suites pass even **without** a generated Prisma client, reproducing the CI environment.
- `prettier --check "src/**"` — passes.

## Notes / follow-ups

- The `Invoice` schema changed, so a migration must be generated and applied (`npm run prisma:migrate`) in environments with a database. No migration files are committed because the repo has no migrations baseline yet.
- Payment/settlement flow (moving `PENDING` → `PAID`, setting `invoiceId`/`datePaid`) is out of scope here and left for a follow-up.

Closes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added invoice management support, including creating, listing, viewing, and voiding invoices.
  * Introduced draft invoice status and improved invoice URL generation.
  * Added filtering and pagination for invoice lists.

* **Bug Fixes**
  * Improved validation for invoice amounts, tokens, emails, dates, and pagination values.
  * Prevented voiding invoices unless they are in a pending state.
  * Added clearer handling for unauthorized and missing-invoice cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->