### PR TITLE
feat: redesign Prisma schema for full domain model

### DIFF
--- a/prisma/migrations/20260623000000_init/migration.sql
+++ b/prisma/migrations/20260623000000_init/migration.sql
@@ -1,5 +1,8 @@
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "public";
+
 -- CreateEnum
-CREATE TYPE "Status" AS ENUM ('PENDING', 'PAID', 'CANCELLED');
+CREATE TYPE "InvoiceStatus" AS ENUM ('PENDING', 'PAID', 'CANCELLED', 'EXPIRED');
 
 -- CreateTable
 CREATE TABLE "Admin" (
@@ -15,11 +18,18 @@ CREATE TABLE "Admin" (
 CREATE TABLE "Merchant" (
     "id" TEXT NOT NULL,
     "merchantId" INTEGER NOT NULL,
+    "address" TEXT NOT NULL,
     "email" TEXT,
     "firstName" TEXT,
-    "address" TEXT NOT NULL,
+    "lastName" TEXT,
+    "businessName" TEXT,
+    "category" TEXT,
+    "description" TEXT,
+    "logo" TEXT,
     "active" BOOLEAN NOT NULL DEFAULT true,
     "verified" BOOLEAN NOT NULL DEFAULT false,
+    "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+    "registered" BOOLEAN NOT NULL DEFAULT false,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
@@ -41,6 +51,31 @@ CREATE TABLE "AuthNonce" (
 );
 
 -- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "merchantId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" TEXT NOT NULL,
+    "merchantId" TEXT NOT NULL,
+    "keyHash" TEXT NOT NULL,
+    "name" TEXT,
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "AcceptedToken" (
     "id" TEXT NOT NULL,
     "token" TEXT NOT NULL,
@@ -51,54 +86,62 @@ CREATE TABLE "AcceptedToken" (
 );
 
 -- CreateTable
-CREATE TABLE "MerchantSession" (
-    "id" TEXT NOT NULL,
-    "merchantId" TEXT NOT NULL,
-    "token" TEXT NOT NULL,
-    "expiresAt" TIMESTAMP(3) NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "MerchantSession_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
 CREATE TABLE "Invoice" (
     "id" TEXT NOT NULL,
     "invoiceId" INTEGER NOT NULL,
+    "paymentSlug" TEXT NOT NULL,
     "amount" BIGINT NOT NULL,
     "token" TEXT NOT NULL,
     "merchantId" TEXT NOT NULL,
     "ref" TEXT NOT NULL,
     "payer" TEXT,
     "email" TEXT,
+    "status" "InvoiceStatus" NOT NULL,
+    "datePaid" TIMESTAMP(3),
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
-    "status" "Status" NOT NULL,
-    "datePaid" TIMESTAMP(3),
 
     CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "Admin_address_key" ON "Admin"("address");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "Merchant_merchantId_key" ON "Merchant"("merchantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Merchant_address_key" ON "Merchant"("address");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Merchant_email_key" ON "Merchant"("email");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "AuthNonce_nonce_key" ON "AuthNonce"("nonce");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_token_key" ON "RefreshToken"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_keyHash_key" ON "ApiKey"("keyHash");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "AcceptedToken_token_key" ON "AcceptedToken"("token");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "MerchantSession_token_key" ON "MerchantSession"("token");
+CREATE UNIQUE INDEX "Invoice_invoiceId_key" ON "Invoice"("invoiceId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Invoice_invoiceId_key" ON "Invoice"("invoiceId");
+CREATE UNIQUE INDEX "Invoice_paymentSlug_key" ON "Invoice"("paymentSlug");
 
 -- AddForeignKey
 ALTER TABLE "AuthNonce" ADD CONSTRAINT "AuthNonce_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "MerchantSession" ADD CONSTRAINT "MerchantSession_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260623000000_init/migration.sql
+++ b/prisma/migrations/20260623000000_init/migration.sql
@@ -2,7 +2,16 @@
 CREATE SCHEMA IF NOT EXISTS "public";
 
 -- CreateEnum
-CREATE TYPE "InvoiceStatus" AS ENUM ('PENDING', 'PAID', 'CANCELLED', 'EXPIRED');
+CREATE TYPE "InvoiceStatus" AS ENUM ('PENDING', 'PAID', 'CANCELLED', 'REFUNDED', 'PARTIALLY_REFUNDED', 'PARTIALLY_PAID', 'DRAFT');
+
+-- CreateEnum
+CREATE TYPE "InvoicePricingMode" AS ENUM ('FIXED_CRYPTO', 'FIXED_FIAT');
+
+-- CreateEnum
+CREATE TYPE "SubscriptionStatus" AS ENUM ('ACTIVE', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "TransactionType" AS ENUM ('INVOICE_PAYMENT', 'SUBSCRIPTION_CHARGE');
 
 -- CreateTable
 CREATE TABLE "Admin" (
@@ -19,6 +28,7 @@ CREATE TABLE "Merchant" (
     "id" TEXT NOT NULL,
     "merchantId" INTEGER NOT NULL,
     "address" TEXT NOT NULL,
+    "account" TEXT,
     "email" TEXT,
     "firstName" TEXT,
     "lastName" TEXT,
@@ -26,6 +36,7 @@ CREATE TABLE "Merchant" (
     "category" TEXT,
     "description" TEXT,
     "logo" TEXT,
+    "webhook" TEXT,
     "active" BOOLEAN NOT NULL DEFAULT true,
     "verified" BOOLEAN NOT NULL DEFAULT false,
     "emailVerified" BOOLEAN NOT NULL DEFAULT false,
@@ -90,18 +101,114 @@ CREATE TABLE "Invoice" (
     "id" TEXT NOT NULL,
     "invoiceId" INTEGER NOT NULL,
     "paymentSlug" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
     "amount" BIGINT NOT NULL,
+    "amountPaid" BIGINT NOT NULL DEFAULT 0,
+    "amountRefunded" BIGINT NOT NULL DEFAULT 0,
     "token" TEXT NOT NULL,
     "merchantId" TEXT NOT NULL,
-    "ref" TEXT NOT NULL,
     "payer" TEXT,
     "email" TEXT,
-    "status" "InvoiceStatus" NOT NULL,
+    "status" "InvoiceStatus" NOT NULL DEFAULT 'DRAFT',
+    "pricingMode" "InvoicePricingMode" NOT NULL DEFAULT 'FIXED_CRYPTO',
+    "fiatCurrency" TEXT,
+    "fiatAmount" BIGINT,
+    "fiatDecimals" INTEGER,
+    "expiresAt" TIMESTAMP(3),
     "datePaid" TIMESTAMP(3),
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MerchantAnalytics" (
+    "id" TEXT NOT NULL,
+    "merchantId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "totalVolume" BIGINT NOT NULL DEFAULT 0,
+    "totalFees" BIGINT NOT NULL DEFAULT 0,
+    "transactionCount" BIGINT NOT NULL DEFAULT 0,
+    "lastUpdated" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MerchantAnalytics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SubscriptionPlan" (
+    "id" TEXT NOT NULL,
+    "planId" INTEGER NOT NULL,
+    "merchantId" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "amount" BIGINT NOT NULL,
+    "interval" INTEGER NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SubscriptionPlan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Subscription" (
+    "id" TEXT NOT NULL,
+    "subscriptionId" INTEGER NOT NULL,
+    "planId" TEXT NOT NULL,
+    "merchantId" TEXT NOT NULL,
+    "customer" TEXT NOT NULL,
+    "status" "SubscriptionStatus" NOT NULL DEFAULT 'ACTIVE',
+    "lastCharged" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Subscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Transaction" (
+    "id" TEXT NOT NULL,
+    "transactionType" "TransactionType" NOT NULL,
+    "refId" INTEGER NOT NULL,
+    "amount" BIGINT NOT NULL,
+    "token" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "merchantId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Transaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TokenAnalytics" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "totalVolume" BIGINT NOT NULL DEFAULT 0,
+    "totalFees" BIGINT NOT NULL DEFAULT 0,
+    "transactionCount" BIGINT NOT NULL DEFAULT 0,
+    "uniqueMerchants" INTEGER NOT NULL DEFAULT 0,
+    "lastUpdated" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TokenAnalytics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BridgePayment" (
+    "id" TEXT NOT NULL,
+    "invoiceId" TEXT NOT NULL,
+    "merchantId" TEXT NOT NULL,
+    "payer" TEXT,
+    "sourceChain" TEXT NOT NULL,
+    "destinationChain" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "amount" BIGINT NOT NULL,
+    "destinationRecipient" TEXT NOT NULL,
+    "memo" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BridgePayment_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
@@ -134,6 +241,18 @@ CREATE UNIQUE INDEX "Invoice_invoiceId_key" ON "Invoice"("invoiceId");
 -- CreateIndex
 CREATE UNIQUE INDEX "Invoice_paymentSlug_key" ON "Invoice"("paymentSlug");
 
+-- CreateIndex
+CREATE UNIQUE INDEX "MerchantAnalytics_merchantId_token_key" ON "MerchantAnalytics"("merchantId", "token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SubscriptionPlan_planId_key" ON "SubscriptionPlan"("planId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subscription_subscriptionId_key" ON "Subscription"("subscriptionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TokenAnalytics_token_key" ON "TokenAnalytics"("token");
+
 -- AddForeignKey
 ALTER TABLE "AuthNonce" ADD CONSTRAINT "AuthNonce_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
@@ -145,3 +264,24 @@ ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_merchantId_fkey" FOREIGN KEY ("merch
 
 -- AddForeignKey
 ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MerchantAnalytics" ADD CONSTRAINT "MerchantAnalytics_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SubscriptionPlan" ADD CONSTRAINT "SubscriptionPlan_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_planId_fkey" FOREIGN KEY ("planId") REFERENCES "SubscriptionPlan"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BridgePayment" ADD CONSTRAINT "BridgePayment_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BridgePayment" ADD CONSTRAINT "BridgePayment_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260623000000_init/migration.sql
+++ b/prisma/migrations/20260623000000_init/migration.sql
@@ -99,7 +99,7 @@ CREATE TABLE "AcceptedToken" (
 -- CreateTable
 CREATE TABLE "Invoice" (
     "id" TEXT NOT NULL,
-    "invoiceId" INTEGER NOT NULL,
+    "invoiceId" INTEGER,
     "paymentSlug" TEXT NOT NULL,
     "description" TEXT NOT NULL,
     "amount" BIGINT NOT NULL,
@@ -242,10 +242,16 @@ CREATE UNIQUE INDEX "Invoice_invoiceId_key" ON "Invoice"("invoiceId");
 CREATE UNIQUE INDEX "Invoice_paymentSlug_key" ON "Invoice"("paymentSlug");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "Invoice_id_merchantId_key" ON "Invoice"("id", "merchantId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "MerchantAnalytics_merchantId_token_key" ON "MerchantAnalytics"("merchantId", "token");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "SubscriptionPlan_planId_key" ON "SubscriptionPlan"("planId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SubscriptionPlan_id_merchantId_key" ON "SubscriptionPlan"("id", "merchantId");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Subscription_subscriptionId_key" ON "Subscription"("subscriptionId");
@@ -272,16 +278,10 @@ ALTER TABLE "MerchantAnalytics" ADD CONSTRAINT "MerchantAnalytics_merchantId_fke
 ALTER TABLE "SubscriptionPlan" ADD CONSTRAINT "SubscriptionPlan_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_planId_fkey" FOREIGN KEY ("planId") REFERENCES "SubscriptionPlan"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_planId_merchantId_fkey" FOREIGN KEY ("planId", "merchantId") REFERENCES "SubscriptionPlan"("id", "merchantId") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "BridgePayment" ADD CONSTRAINT "BridgePayment_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "BridgePayment" ADD CONSTRAINT "BridgePayment_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "BridgePayment" ADD CONSTRAINT "BridgePayment_invoiceId_merchantId_fkey" FOREIGN KEY ("invoiceId", "merchantId") REFERENCES "Invoice"("id", "merchantId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,9 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -12,45 +6,69 @@ datasource db {
   provider = "postgresql"
 }
 
+// Retained: admin-level access control is a separate auth concern handled outside merchant flows.
 model Admin {
   id        String   @id @default(uuid())
-  address   String
+  address   String   @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
 
 model Merchant {
-  id            String   @id @default(uuid())
-  merchantId    Int      @unique
-  email         String?  @unique
-  address       String
+  id            String    @id @default(uuid())
+  merchantId    Int       @unique
+  address       String    @unique
+  email         String?   @unique
   firstName     String?
   lastName      String?
   businessName  String?
   category      String?
   description   String?
   logo          String?
-  active        Boolean  @default(true)
-  verified      Boolean  @default(false)
-  emailVerified Boolean  @default(false)
-  registered    Boolean  @default(false)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
-  sessions      MerchantSession[]
+  active        Boolean   @default(true)
+  verified      Boolean   @default(false)
+  emailVerified Boolean   @default(false)
+  registered    Boolean   @default(false)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  refreshTokens RefreshToken[]
   invoices      Invoice[]
-  nonces    AuthNonce[]
+  nonces        AuthNonce[]
+  apiKeys       ApiKey[]
 }
 
 model AuthNonce {
-  id        String    @id @default(uuid())
-  address   String
-  nonce     String    @unique
-  message   String
-  expiresAt DateTime
-  usedAt    DateTime?
-  createdAt DateTime  @default(now())
+  id         String    @id @default(uuid())
+  address    String
+  nonce      String    @unique
+  message    String
+  expiresAt  DateTime
+  usedAt     DateTime?
+  createdAt  DateTime  @default(now())
   merchantId String?
-  merchant  Merchant? @relation(fields: [merchantId], references: [id])
+  merchant   Merchant? @relation(fields: [merchantId], references: [id])
+}
+
+model RefreshToken {
+  id         String   @id @default(uuid())
+  merchantId String
+  merchant   Merchant @relation(fields: [merchantId], references: [id])
+  token      String   @unique
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
+}
+
+model ApiKey {
+  id         String    @id @default(uuid())
+  merchantId String
+  merchant   Merchant  @relation(fields: [merchantId], references: [id])
+  keyHash    String    @unique
+  name       String?
+  lastUsedAt DateTime?
+  expiresAt  DateTime?
+  revokedAt  DateTime?
+  createdAt  DateTime  @default(now())
 }
 
 model AcceptedToken {
@@ -60,33 +78,26 @@ model AcceptedToken {
   updatedAt DateTime @updatedAt
 }
 
-model MerchantSession {
-  id        String   @id @default(uuid())
-  merchantId String
-  merchant  Merchant @relation(fields: [merchantId], references: [id])
-  token     String   @unique
-  expiresAt DateTime
-  createdAt DateTime @default(now())
-}
-
-enum Status {
+enum InvoiceStatus {
   PENDING
   PAID
   CANCELLED
+  EXPIRED
 }
 
 model Invoice {
-  id        String   @id @default(uuid())
-  invoiceId Int      @unique
-  amount    BigInt
-  token     String
-  merchantId String
-  merchant  Merchant @relation(fields: [merchantId], references: [id])
-  ref       String
-  payer     String?
-  email     String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  status    Status
-  datePaid  DateTime?
+  id           String        @id @default(uuid())
+  invoiceId    Int           @unique
+  paymentSlug  String        @unique
+  amount       BigInt
+  token        String
+  merchantId   String
+  merchant     Merchant      @relation(fields: [merchantId], references: [id])
+  ref          String
+  payer        String?
+  email        String?
+  status       InvoiceStatus
+  datePaid     DateTime?
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,9 +40,7 @@ model Merchant {
   apiKeys            ApiKey[]
   analytics          MerchantAnalytics[]
   subscriptionPlans  SubscriptionPlan[]
-  subscriptions      Subscription[]
   transactions       Transaction[]
-  bridgePayments     BridgePayment[]
 }
 
 model AuthNonce {
@@ -103,7 +101,7 @@ enum InvoicePricingMode {
 
 model Invoice {
   id               String             @id @default(uuid())
-  invoiceId        Int                @unique
+  invoiceId        Int?               @unique
   paymentSlug      String             @unique
   description      String
   amount           BigInt
@@ -125,6 +123,9 @@ model Invoice {
   updatedAt        DateTime           @updatedAt
 
   bridgePayments   BridgePayment[]
+
+  // Enables the composite FK on BridgePayment that enforces invoiceId+merchantId consistency.
+  @@unique([id, merchantId])
 }
 
 // Per-token analytics for a merchant. Composite unique mirrors the contract key.
@@ -155,6 +156,9 @@ model SubscriptionPlan {
   updatedAt     DateTime       @updatedAt
 
   subscriptions Subscription[]
+
+  // Enables the composite FK on Subscription that enforces planId+merchantId consistency.
+  @@unique([id, merchantId])
 }
 
 enum SubscriptionStatus {
@@ -166,9 +170,11 @@ model Subscription {
   id             String             @id @default(uuid())
   subscriptionId Int                @unique
   planId         String
-  plan           SubscriptionPlan   @relation(fields: [planId], references: [id])
   merchantId     String
-  merchant       Merchant           @relation(fields: [merchantId], references: [id])
+  // Composite FK: DB rejects a subscription whose merchantId differs from its plan's merchantId.
+  // Prisma forbids a scalar from appearing in two @relation fields arrays, so the separate
+  // Merchant relation is intentionally absent here — reach merchant via plan.merchant.
+  plan           SubscriptionPlan   @relation(fields: [planId, merchantId], references: [id, merchantId])
   customer       String
   status         SubscriptionStatus @default(ACTIVE)
   lastCharged    DateTime?
@@ -207,9 +213,11 @@ model TokenAnalytics {
 model BridgePayment {
   id                   String   @id @default(uuid())
   invoiceId            String
-  invoice              Invoice  @relation(fields: [invoiceId], references: [id])
   merchantId           String
-  merchant             Merchant @relation(fields: [merchantId], references: [id])
+  // Composite FK: DB rejects a bridge payment whose merchantId differs from its invoice's merchantId.
+  // Prisma forbids a scalar from appearing in two @relation fields arrays, so the separate
+  // Merchant relation is intentionally absent here — reach merchant via invoice.merchant.
+  invoice              Invoice  @relation(fields: [invoiceId, merchantId], references: [id, merchantId])
   payer                String?
   sourceChain          String
   destinationChain     String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Merchant {
   id            String    @id @default(uuid())
   merchantId    Int       @unique
   address       String    @unique
+  account       String?
   email         String?   @unique
   firstName     String?
   lastName      String?
@@ -25,6 +26,7 @@ model Merchant {
   category      String?
   description   String?
   logo          String?
+  webhook       String?
   active        Boolean   @default(true)
   verified      Boolean   @default(false)
   emailVerified Boolean   @default(false)
@@ -32,10 +34,15 @@ model Merchant {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  refreshTokens RefreshToken[]
-  invoices      Invoice[]
-  nonces        AuthNonce[]
-  apiKeys       ApiKey[]
+  refreshTokens      RefreshToken[]
+  invoices           Invoice[]
+  nonces             AuthNonce[]
+  apiKeys            ApiKey[]
+  analytics          MerchantAnalytics[]
+  subscriptionPlans  SubscriptionPlan[]
+  subscriptions      Subscription[]
+  transactions       Transaction[]
+  bridgePayments     BridgePayment[]
 }
 
 model AuthNonce {
@@ -78,26 +85,137 @@ model AcceptedToken {
   updatedAt DateTime @updatedAt
 }
 
+// Matches the smart contract InvoiceStatus enum exactly.
 enum InvoiceStatus {
   PENDING
   PAID
   CANCELLED
-  EXPIRED
+  REFUNDED
+  PARTIALLY_REFUNDED
+  PARTIALLY_PAID
+  DRAFT
+}
+
+enum InvoicePricingMode {
+  FIXED_CRYPTO
+  FIXED_FIAT
 }
 
 model Invoice {
-  id           String        @id @default(uuid())
-  invoiceId    Int           @unique
-  paymentSlug  String        @unique
-  amount       BigInt
-  token        String
-  merchantId   String
-  merchant     Merchant      @relation(fields: [merchantId], references: [id])
-  ref          String
-  payer        String?
-  email        String?
-  status       InvoiceStatus
-  datePaid     DateTime?
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
+  id               String             @id @default(uuid())
+  invoiceId        Int                @unique
+  paymentSlug      String             @unique
+  description      String
+  amount           BigInt
+  amountPaid       BigInt             @default(0)
+  amountRefunded   BigInt             @default(0)
+  token            String
+  merchantId       String
+  merchant         Merchant           @relation(fields: [merchantId], references: [id])
+  payer            String?
+  email            String?
+  status           InvoiceStatus      @default(DRAFT)
+  pricingMode      InvoicePricingMode @default(FIXED_CRYPTO)
+  fiatCurrency     String?
+  fiatAmount       BigInt?
+  fiatDecimals     Int?
+  expiresAt        DateTime?
+  datePaid         DateTime?
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime           @updatedAt
+
+  bridgePayments   BridgePayment[]
+}
+
+// Per-token analytics for a merchant. Composite unique mirrors the contract key.
+model MerchantAnalytics {
+  id               String   @id @default(uuid())
+  merchantId       String
+  merchant         Merchant @relation(fields: [merchantId], references: [id])
+  token            String
+  totalVolume      BigInt   @default(0)
+  totalFees        BigInt   @default(0)
+  transactionCount BigInt   @default(0)
+  lastUpdated      DateTime @updatedAt
+
+  @@unique([merchantId, token])
+}
+
+model SubscriptionPlan {
+  id            String         @id @default(uuid())
+  planId        Int            @unique
+  merchantId    String
+  merchant      Merchant       @relation(fields: [merchantId], references: [id])
+  description   String
+  token         String
+  amount        BigInt
+  interval      Int
+  active        Boolean        @default(true)
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+
+  subscriptions Subscription[]
+}
+
+enum SubscriptionStatus {
+  ACTIVE
+  CANCELLED
+}
+
+model Subscription {
+  id             String             @id @default(uuid())
+  subscriptionId Int                @unique
+  planId         String
+  plan           SubscriptionPlan   @relation(fields: [planId], references: [id])
+  merchantId     String
+  merchant       Merchant           @relation(fields: [merchantId], references: [id])
+  customer       String
+  status         SubscriptionStatus @default(ACTIVE)
+  lastCharged    DateTime?
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
+}
+
+enum TransactionType {
+  INVOICE_PAYMENT
+  SUBSCRIPTION_CHARGE
+}
+
+model Transaction {
+  id              String          @id @default(uuid())
+  transactionType TransactionType
+  refId           Int
+  amount          BigInt
+  token           String
+  description     String
+  merchantId      String
+  merchant        Merchant        @relation(fields: [merchantId], references: [id])
+  date            DateTime
+  createdAt       DateTime        @default(now())
+}
+
+model TokenAnalytics {
+  id               String   @id @default(uuid())
+  token            String   @unique
+  totalVolume      BigInt   @default(0)
+  totalFees        BigInt   @default(0)
+  transactionCount BigInt   @default(0)
+  uniqueMerchants  Int      @default(0)
+  lastUpdated      DateTime @updatedAt
+}
+
+model BridgePayment {
+  id                   String   @id @default(uuid())
+  invoiceId            String
+  invoice              Invoice  @relation(fields: [invoiceId], references: [id])
+  merchantId           String
+  merchant             Merchant @relation(fields: [merchantId], references: [id])
+  payer                String?
+  sourceChain          String
+  destinationChain     String
+  token                String
+  amount               BigInt
+  destinationRecipient String
+  memo                 String?
+  createdAt            DateTime @default(now())
 }

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -28,7 +28,7 @@ export const authenticateMerchant = async (
       return;
     }
 
-    const session = await prisma.merchantSession.findUnique({
+    const session = await prisma.refreshToken.findUnique({
       where: { token },
       include: { merchant: true },
     });

--- a/src/services/auth.services.ts
+++ b/src/services/auth.services.ts
@@ -88,7 +88,7 @@ export async function issueRefreshToken(merchantId: string): Promise<string> {
   const token = crypto.randomUUID();
   const expiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS);
 
-  await prisma.merchantSession.create({
+  await prisma.refreshToken.create({
     data: { merchantId, token, expiresAt },
   });
 
@@ -112,7 +112,7 @@ export async function authenticateWallet(address: string, nonce: string, signatu
     merchant: {
       id: merchant.id,
       address: merchant.address,
-      isRegistered: merchant.firstName !== null,
+      isRegistered: merchant.registered,
     },
   } as const;
 }

--- a/src/services/invoice.services.ts
+++ b/src/services/invoice.services.ts
@@ -1,4 +1,4 @@
-import type { Invoice, Prisma, Status } from '@prisma/client';
+import type { Invoice, InvoiceStatus as PrismaInvoiceStatus, Prisma } from '@prisma/client';
 import prisma from '../config/prisma.js';
 import { AppError } from '../utils/errors.js';
 import { generatePaymentSlug } from '../utils/slug.js';
@@ -19,7 +19,7 @@ const InvoiceStatus = {
   PENDING: 'PENDING',
   PAID: 'PAID',
   CANCELLED: 'CANCELLED',
-} as const satisfies Record<string, Status>;
+} as const satisfies Record<string, PrismaInvoiceStatus>;
 
 /**
  * Public-facing view of an invoice. `amount` is serialized to a string because
@@ -33,7 +33,7 @@ export const sanitizeInvoice = (invoice: Invoice) => ({
   token: invoice.token,
   status: invoice.status,
   merchantId: invoice.merchantId,
-  payerEmail: invoice.payerEmail,
+  email: invoice.email,
   expiresAt: invoice.expiresAt,
   datePaid: invoice.datePaid,
   createdAt: invoice.createdAt,
@@ -52,7 +52,7 @@ export const createInvoice = async (merchantId: string, data: CreateInvoiceInput
     throw new AppError(400, 'amount must be a positive integer');
   }
 
-  const status: Status = data.isDraft ? InvoiceStatus.DRAFT : InvoiceStatus.PENDING;
+  const status: PrismaInvoiceStatus = data.isDraft ? InvoiceStatus.DRAFT : InvoiceStatus.PENDING;
   const expiresAt = data.expiresAt ? new Date(data.expiresAt) : null;
 
   for (let attempt = 0; attempt < SLUG_MAX_RETRIES; attempt++) {
@@ -63,7 +63,7 @@ export const createInvoice = async (merchantId: string, data: CreateInvoiceInput
           description: data.description.trim(),
           amount,
           token: data.token.trim(),
-          payerEmail: data.payerEmail?.trim() ?? null,
+          email: data.payerEmail?.trim() ?? null,
           expiresAt,
           status,
           paymentSlug: generatePaymentSlug(),

--- a/src/utils/invoice.validation.ts
+++ b/src/utils/invoice.validation.ts
@@ -1,4 +1,4 @@
-import type { Status } from '@prisma/client';
+import type { InvoiceStatus } from '@prisma/client';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const POSITIVE_INTEGER_REGEX = /^\d+$/;
@@ -11,7 +11,10 @@ const INVOICE_STATUSES = [
   'PENDING',
   'PAID',
   'CANCELLED',
-] as const satisfies readonly Status[];
+  'REFUNDED',
+  'PARTIALLY_REFUNDED',
+  'PARTIALLY_PAID',
+] as const satisfies readonly InvoiceStatus[];
 
 export const DEFAULT_LIMIT = 20;
 export const MAX_LIMIT = 100;
@@ -26,7 +29,7 @@ export interface CreateInvoiceInput {
 }
 
 export interface InvoiceListFilters {
-  status?: Status;
+  status?: InvoiceStatus;
   token?: string;
   startDate?: Date;
   endDate?: Date;
@@ -118,7 +121,7 @@ export const parseInvoiceListQuery = (query: Record<string, unknown>): ParsedLis
   if (query.status !== undefined) {
     const status = String(query.status).toUpperCase();
     if ((INVOICE_STATUSES as readonly string[]).includes(status)) {
-      filters.status = status as Status;
+      filters.status = status as InvoiceStatus;
     } else {
       errors.status = `status must be one of ${INVOICE_STATUSES.join(', ')}`;
     }

--- a/tests/integration/auth.routes.test.ts
+++ b/tests/integration/auth.routes.test.ts
@@ -56,15 +56,24 @@ describe('Auth Routes', () => {
       prismaMock.merchant.create.mockResolvedValue({
         id: 'merchant-uuid',
         merchantId: 123456,
+        address,
+        account: null,
         email: null,
         firstName: null,
-        address,
+        lastName: null,
+        businessName: null,
+        category: null,
+        description: null,
+        logo: null,
+        webhook: null,
         active: true,
         verified: false,
+        emailVerified: false,
+        registered: false,
         createdAt: mockDate,
         updatedAt: mockDate,
       });
-      prismaMock.merchantSession.create.mockResolvedValue({
+      prismaMock.refreshToken.create.mockResolvedValue({
         id: 'session-uuid',
         merchantId: 'merchant-uuid',
         token: 'refresh-uuid',
@@ -94,15 +103,24 @@ describe('Auth Routes', () => {
       prismaMock.merchant.findFirst.mockResolvedValue({
         id: 'merchant-uuid',
         merchantId: 123456,
+        address,
+        account: null,
         email: 'test@merchant.com',
         firstName: 'Jane',
-        address,
+        lastName: 'Doe',
+        businessName: 'Acme',
+        category: 'retail',
+        description: null,
+        logo: null,
+        webhook: null,
         active: true,
         verified: true,
+        emailVerified: true,
+        registered: true,
         createdAt: mockDate,
         updatedAt: mockDate,
       });
-      prismaMock.merchantSession.create.mockResolvedValue({
+      prismaMock.refreshToken.create.mockResolvedValue({
         id: 'session-uuid',
         merchantId: 'merchant-uuid',
         token: 'refresh-uuid',

--- a/tests/integration/invoice.routes.test.ts
+++ b/tests/integration/invoice.routes.test.ts
@@ -9,9 +9,22 @@ const MERCHANT_ID = 'merchant-1';
 const merchant = {
   id: MERCHANT_ID,
   merchantId: 1,
-  email: 'merchant@example.com',
   address: '0x123',
+  account: null,
+  email: 'merchant@example.com',
+  firstName: null,
+  lastName: null,
+  businessName: null,
+  category: null,
+  description: null,
+  logo: null,
+  webhook: null,
+  active: true,
+  verified: false,
+  emailVerified: false,
   registered: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
 };
 
 const baseInvoice = {
@@ -34,7 +47,7 @@ const baseInvoice = {
 };
 
 const authenticate = () => {
-  prismaMock.merchantSession.findUnique.mockResolvedValue({
+  prismaMock.refreshToken.findUnique.mockResolvedValue({
     id: 'session-1',
     merchantId: MERCHANT_ID,
     token: 'valid-token',

--- a/tests/integration/merchant.register.test.ts
+++ b/tests/integration/merchant.register.test.ts
@@ -18,14 +18,16 @@ const REGISTER_URL = '/api/v1/merchants/register';
 const baseMerchant = {
   id: 'uuid-1',
   merchantId: 1,
-  email: null,
   address: '0x123',
+  account: null,
+  email: null,
   firstName: null,
   lastName: null,
   businessName: null,
   category: null,
   description: null,
   logo: null,
+  webhook: null,
   active: true,
   verified: false,
   emailVerified: false,
@@ -44,7 +46,7 @@ const validPayload = {
 };
 
 const authenticateAs = (merchant: Record<string, unknown>) => {
-  prismaMock.merchantSession.findUnique.mockResolvedValue({
+  prismaMock.refreshToken.findUnique.mockResolvedValue({
     id: 'session-1',
     merchantId: merchant.id,
     token: 'valid-token',

--- a/tests/unit/analytics.schema.test.ts
+++ b/tests/unit/analytics.schema.test.ts
@@ -1,0 +1,318 @@
+import { mockReset } from 'jest-mock-extended';
+import { TransactionType } from '@prisma/client';
+
+const { default: prismaMock } = (await import('../../src/config/prisma.js')) as any;
+
+const mockDate = new Date('2026-06-24T10:00:00Z');
+const TOKEN = 'CABC...TOKEN';
+const MERCHANT_ID = 'merchant-uuid';
+const MERCHANT_ADDR = 'GABCDEF123';
+
+describe('MerchantAnalytics schema', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  const baseAnalytics = {
+    id: 'analytics-uuid',
+    merchantId: MERCHANT_ID,
+    token: TOKEN,
+    totalVolume: BigInt(0),
+    totalFees: BigInt(0),
+    transactionCount: BigInt(0),
+    lastUpdated: mockDate,
+  };
+
+  describe('create', () => {
+    test('creates a zeroed analytics record for a merchant+token pair', async () => {
+      prismaMock.merchantAnalytics.create.mockResolvedValue(baseAnalytics);
+
+      const result = await prismaMock.merchantAnalytics.create({
+        data: {
+          merchantId: MERCHANT_ID,
+          token: TOKEN,
+        },
+      });
+
+      expect(result.totalVolume).toBe(BigInt(0));
+      expect(result.totalFees).toBe(BigInt(0));
+      expect(result.transactionCount).toBe(BigInt(0));
+    });
+
+    test('upserts accumulated totals for an existing merchant+token pair', async () => {
+      const updated = {
+        ...baseAnalytics,
+        totalVolume: BigInt(5_000_000),
+        totalFees: BigInt(50_000),
+        transactionCount: BigInt(3),
+      };
+      prismaMock.merchantAnalytics.upsert.mockResolvedValue(updated);
+
+      const result = await prismaMock.merchantAnalytics.upsert({
+        where: { merchantId_token: { merchantId: MERCHANT_ID, token: TOKEN } },
+        create: { merchantId: MERCHANT_ID, token: TOKEN },
+        update: {
+          totalVolume: { increment: BigInt(5_000_000) },
+          totalFees: { increment: BigInt(50_000) },
+          transactionCount: { increment: BigInt(3) },
+        },
+      });
+
+      expect(result.totalVolume).toBe(BigInt(5_000_000));
+      expect(result.transactionCount).toBe(BigInt(3));
+      expect(prismaMock.merchantAnalytics.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { merchantId_token: { merchantId: MERCHANT_ID, token: TOKEN } },
+        }),
+      );
+    });
+  });
+
+  describe('composite unique constraint', () => {
+    test('findUnique by merchantId+token composite key returns the record', async () => {
+      prismaMock.merchantAnalytics.findUnique.mockResolvedValue(baseAnalytics);
+
+      const result = await prismaMock.merchantAnalytics.findUnique({
+        where: { merchantId_token: { merchantId: MERCHANT_ID, token: TOKEN } },
+      });
+
+      expect(result).toEqual(baseAnalytics);
+    });
+
+    test('rejects duplicate merchantId+token pair with P2002', async () => {
+      const uniqueError = Object.assign(new Error('Unique constraint failed'), {
+        code: 'P2002',
+        meta: { target: ['merchantId', 'token'] },
+      });
+      prismaMock.merchantAnalytics.create.mockRejectedValue(uniqueError);
+
+      await expect(
+        prismaMock.merchantAnalytics.create({
+          data: { merchantId: MERCHANT_ID, token: TOKEN },
+        }),
+      ).rejects.toMatchObject({ code: 'P2002' });
+    });
+  });
+});
+
+describe('TokenAnalytics schema', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  const baseTokenAnalytics = {
+    id: 'token-analytics-uuid',
+    token: TOKEN,
+    totalVolume: BigInt(0),
+    totalFees: BigInt(0),
+    transactionCount: BigInt(0),
+    uniqueMerchants: 0,
+    lastUpdated: mockDate,
+  };
+
+  test('creates a zeroed analytics record for a token', async () => {
+    prismaMock.tokenAnalytics.create.mockResolvedValue(baseTokenAnalytics);
+
+    const result = await prismaMock.tokenAnalytics.create({ data: { token: TOKEN } });
+
+    expect(result.token).toBe(TOKEN);
+    expect(result.totalVolume).toBe(BigInt(0));
+    expect(result.uniqueMerchants).toBe(0);
+  });
+
+  test('findUnique by token address', async () => {
+    prismaMock.tokenAnalytics.findUnique.mockResolvedValue(baseTokenAnalytics);
+
+    const result = await prismaMock.tokenAnalytics.findUnique({ where: { token: TOKEN } });
+
+    expect(result).toEqual(baseTokenAnalytics);
+  });
+
+  test('increments counters when a payment is processed', async () => {
+    const updated = {
+      ...baseTokenAnalytics,
+      totalVolume: BigInt(1_000_000),
+      totalFees: BigInt(10_000),
+      transactionCount: BigInt(1),
+      uniqueMerchants: 1,
+    };
+    prismaMock.tokenAnalytics.update.mockResolvedValue(updated);
+
+    const result = await prismaMock.tokenAnalytics.update({
+      where: { token: TOKEN },
+      data: {
+        totalVolume: { increment: BigInt(1_000_000) },
+        totalFees: { increment: BigInt(10_000) },
+        transactionCount: { increment: BigInt(1) },
+        uniqueMerchants: { increment: 1 },
+      },
+    });
+
+    expect(result.totalVolume).toBe(BigInt(1_000_000));
+    expect(result.uniqueMerchants).toBe(1);
+  });
+
+  test('rejects duplicate token with P2002', async () => {
+    const uniqueError = Object.assign(new Error('Unique constraint failed'), {
+      code: 'P2002',
+      meta: { target: ['token'] },
+    });
+    prismaMock.tokenAnalytics.create.mockRejectedValue(uniqueError);
+
+    await expect(
+      prismaMock.tokenAnalytics.create({ data: { token: TOKEN } }),
+    ).rejects.toMatchObject({ code: 'P2002', meta: { target: ['token'] } });
+  });
+});
+
+describe('Transaction schema', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  const baseTransaction = {
+    id: 'tx-uuid',
+    transactionType: TransactionType.INVOICE_PAYMENT,
+    refId: 1001,
+    amount: BigInt(1_000_000),
+    token: TOKEN,
+    description: 'Invoice #1001 payment',
+    merchantId: MERCHANT_ID,
+    date: mockDate,
+    createdAt: mockDate,
+  };
+
+  test('creates an INVOICE_PAYMENT transaction', async () => {
+    prismaMock.transaction.create.mockResolvedValue(baseTransaction);
+
+    const result = await prismaMock.transaction.create({
+      data: {
+        transactionType: TransactionType.INVOICE_PAYMENT,
+        refId: 1001,
+        amount: BigInt(1_000_000),
+        token: TOKEN,
+        description: 'Invoice #1001 payment',
+        merchantId: MERCHANT_ID,
+        date: mockDate,
+      },
+    });
+
+    expect(result.transactionType).toBe(TransactionType.INVOICE_PAYMENT);
+    expect(result.refId).toBe(1001);
+    expect(result.amount).toBe(BigInt(1_000_000));
+  });
+
+  test('creates a SUBSCRIPTION_CHARGE transaction', async () => {
+    const subTx = {
+      ...baseTransaction,
+      id: 'tx-uuid-2',
+      transactionType: TransactionType.SUBSCRIPTION_CHARGE,
+      refId: 501,
+      description: 'Subscription #501 charge',
+    };
+    prismaMock.transaction.create.mockResolvedValue(subTx);
+
+    const result = await prismaMock.transaction.create({
+      data: {
+        transactionType: TransactionType.SUBSCRIPTION_CHARGE,
+        refId: 501,
+        amount: BigInt(10_000_000),
+        token: TOKEN,
+        description: 'Subscription #501 charge',
+        merchantId: MERCHANT_ID,
+        date: mockDate,
+      },
+    });
+
+    expect(result.transactionType).toBe(TransactionType.SUBSCRIPTION_CHARGE);
+    expect(result.refId).toBe(501);
+  });
+
+  test('findMany returns all transactions for a merchant', async () => {
+    prismaMock.transaction.findMany.mockResolvedValue([baseTransaction]);
+
+    const result = await prismaMock.transaction.findMany({
+      where: { merchantId: MERCHANT_ID },
+      orderBy: { date: 'desc' },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].merchantId).toBe(MERCHANT_ID);
+  });
+});
+
+describe('BridgePayment schema', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  const baseBridgePayment = {
+    id: 'bridge-uuid',
+    invoiceId: 'invoice-uuid',
+    merchantId: MERCHANT_ID,
+    payer: MERCHANT_ADDR,
+    sourceChain: 'stellar',
+    destinationChain: 'ethereum',
+    token: TOKEN,
+    amount: BigInt(1_000_000),
+    destinationRecipient: '0xABCD...1234',
+    memo: null,
+    createdAt: mockDate,
+  };
+
+  test('creates a bridge payment record', async () => {
+    prismaMock.bridgePayment.create.mockResolvedValue(baseBridgePayment);
+
+    const result = await prismaMock.bridgePayment.create({
+      data: {
+        invoiceId: 'invoice-uuid',
+        merchantId: MERCHANT_ID,
+        payer: MERCHANT_ADDR,
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        token: TOKEN,
+        amount: BigInt(1_000_000),
+        destinationRecipient: '0xABCD...1234',
+      },
+    });
+
+    expect(result.sourceChain).toBe('stellar');
+    expect(result.destinationChain).toBe('ethereum');
+    expect(result.destinationRecipient).toBe('0xABCD...1234');
+    expect(result.payer).toBe(MERCHANT_ADDR);
+    expect(result.memo).toBeNull();
+  });
+
+  test('creates a bridge payment with an optional memo', async () => {
+    const withMemo = { ...baseBridgePayment, memo: 'order-ref-789' };
+    prismaMock.bridgePayment.create.mockResolvedValue(withMemo);
+
+    const result = await prismaMock.bridgePayment.create({
+      data: { ...baseBridgePayment, memo: 'order-ref-789' },
+    });
+
+    expect(result.memo).toBe('order-ref-789');
+  });
+
+  test('creates a bridge payment with anonymous payer (null)', async () => {
+    const noPayer = { ...baseBridgePayment, payer: null };
+    prismaMock.bridgePayment.create.mockResolvedValue(noPayer);
+
+    const result = await prismaMock.bridgePayment.create({
+      data: { ...baseBridgePayment, payer: null },
+    });
+
+    expect(result.payer).toBeNull();
+  });
+
+  test('findMany returns bridge payments for an invoice', async () => {
+    prismaMock.bridgePayment.findMany.mockResolvedValue([baseBridgePayment]);
+
+    const result = await prismaMock.bridgePayment.findMany({
+      where: { invoiceId: 'invoice-uuid' },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].invoiceId).toBe('invoice-uuid');
+  });
+});

--- a/tests/unit/analytics.schema.test.ts
+++ b/tests/unit/analytics.schema.test.ts
@@ -1,5 +1,12 @@
 import { mockReset } from 'jest-mock-extended';
-import { TransactionType } from '@prisma/client';
+
+// Local mirror of the Prisma enum — never import runtime values from
+// @prisma/client in tests; the generated client may not exist in CI.
+const TransactionType = {
+  INVOICE_PAYMENT: 'INVOICE_PAYMENT',
+  SUBSCRIPTION_CHARGE: 'SUBSCRIPTION_CHARGE',
+} as const;
+type TransactionType = (typeof TransactionType)[keyof typeof TransactionType];
 
 const { default: prismaMock } = (await import('../../src/config/prisma.js')) as any;
 

--- a/tests/unit/auth.services.test.ts
+++ b/tests/unit/auth.services.test.ts
@@ -181,8 +181,8 @@ describe('Auth Services', () => {
   });
 
   describe('issueRefreshToken', () => {
-    test('should create a MerchantSession and return the token', async () => {
-      prismaMock.merchantSession.create.mockResolvedValue({
+    test('should create a RefreshToken and return the token', async () => {
+      prismaMock.refreshToken.create.mockResolvedValue({
         id: 'session-uuid',
         merchantId: 'merchant-uuid',
         token: 'ignored',
@@ -194,7 +194,7 @@ describe('Auth Services', () => {
 
       expect(typeof result).toBe('string');
       expect(result.length).toBeGreaterThan(0);
-      expect(prismaMock.merchantSession.create).toHaveBeenCalledWith({
+      expect(prismaMock.refreshToken.create).toHaveBeenCalledWith({
         data: {
           merchantId: 'merchant-uuid',
           token: expect.any(String),
@@ -225,15 +225,22 @@ describe('Auth Services', () => {
       prismaMock.merchant.create.mockResolvedValue({
         id: 'merchant-uuid',
         merchantId: 123456,
+        address,
         email: null,
         firstName: null,
-        address,
+        lastName: null,
+        businessName: null,
+        category: null,
+        description: null,
+        logo: null,
         active: true,
         verified: false,
+        emailVerified: false,
+        registered: false,
         createdAt: mockDate,
         updatedAt: mockDate,
       });
-      prismaMock.merchantSession.create.mockResolvedValue({
+      prismaMock.refreshToken.create.mockResolvedValue({
         id: 'session-uuid',
         merchantId: 'merchant-uuid',
         token: 'ignored',
@@ -262,15 +269,22 @@ describe('Auth Services', () => {
       prismaMock.merchant.findFirst.mockResolvedValue({
         id: 'existing-merchant-uuid',
         merchantId: 654321,
+        address,
         email: 'merchant@test.com',
         firstName: 'John',
-        address,
+        lastName: 'Doe',
+        businessName: 'Acme',
+        category: 'retail',
+        description: 'A merchant',
+        logo: null,
         active: true,
         verified: true,
+        emailVerified: true,
+        registered: true,
         createdAt: mockDate,
         updatedAt: mockDate,
       });
-      prismaMock.merchantSession.create.mockResolvedValue({
+      prismaMock.refreshToken.create.mockResolvedValue({
         id: 'session-uuid',
         merchantId: 'existing-merchant-uuid',
         token: 'ignored',

--- a/tests/unit/invoice.schema.test.ts
+++ b/tests/unit/invoice.schema.test.ts
@@ -1,5 +1,23 @@
 import { mockReset } from 'jest-mock-extended';
-import { InvoiceStatus, InvoicePricingMode } from '@prisma/client';
+
+// Local mirrors of the Prisma enums — never import runtime values from
+// @prisma/client in tests; the generated client may not exist in CI.
+const InvoiceStatus = {
+  PENDING: 'PENDING',
+  PAID: 'PAID',
+  CANCELLED: 'CANCELLED',
+  REFUNDED: 'REFUNDED',
+  PARTIALLY_REFUNDED: 'PARTIALLY_REFUNDED',
+  PARTIALLY_PAID: 'PARTIALLY_PAID',
+  DRAFT: 'DRAFT',
+} as const;
+type InvoiceStatus = (typeof InvoiceStatus)[keyof typeof InvoiceStatus];
+
+const InvoicePricingMode = {
+  FIXED_CRYPTO: 'FIXED_CRYPTO',
+  FIXED_FIAT: 'FIXED_FIAT',
+} as const;
+type InvoicePricingMode = (typeof InvoicePricingMode)[keyof typeof InvoicePricingMode];
 
 const { default: prismaMock } = (await import('../../src/config/prisma.js')) as any;
 

--- a/tests/unit/invoice.schema.test.ts
+++ b/tests/unit/invoice.schema.test.ts
@@ -1,0 +1,282 @@
+import { mockReset } from 'jest-mock-extended';
+import { InvoiceStatus, InvoicePricingMode } from '@prisma/client';
+
+const { default: prismaMock } = (await import('../../src/config/prisma.js')) as any;
+
+const mockDate = new Date('2026-06-24T10:00:00Z');
+
+const baseMerchant = {
+  id: 'merchant-uuid',
+  merchantId: 1,
+  address: 'GABCDEF123',
+  account: null,
+  email: null,
+  firstName: null,
+  lastName: null,
+  businessName: null,
+  category: null,
+  description: null,
+  logo: null,
+  webhook: null,
+  active: true,
+  verified: false,
+  emailVerified: false,
+  registered: false,
+  createdAt: mockDate,
+  updatedAt: mockDate,
+};
+
+const baseInvoice = {
+  id: 'invoice-uuid',
+  invoiceId: 1001,
+  paymentSlug: 'pay-abc123',
+  description: 'Payment for services',
+  amount: BigInt(1_000_000),
+  amountPaid: BigInt(0),
+  amountRefunded: BigInt(0),
+  token: 'CABC...TOKEN',
+  merchantId: 'merchant-uuid',
+  payer: null,
+  email: null,
+  status: InvoiceStatus.DRAFT,
+  pricingMode: InvoicePricingMode.FIXED_CRYPTO,
+  fiatCurrency: null,
+  fiatAmount: null,
+  fiatDecimals: null,
+  expiresAt: null,
+  datePaid: null,
+  createdAt: mockDate,
+  updatedAt: mockDate,
+};
+
+describe('Invoice schema', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  describe('create', () => {
+    test('creates a DRAFT invoice with FIXED_CRYPTO pricing', async () => {
+      prismaMock.invoice.create.mockResolvedValue(baseInvoice);
+
+      const result = await prismaMock.invoice.create({
+        data: {
+          invoiceId: 1001,
+          paymentSlug: 'pay-abc123',
+          description: 'Payment for services',
+          amount: BigInt(1_000_000),
+          token: 'CABC...TOKEN',
+          merchantId: 'merchant-uuid',
+          status: InvoiceStatus.DRAFT,
+          pricingMode: InvoicePricingMode.FIXED_CRYPTO,
+        },
+      });
+
+      expect(result.status).toBe(InvoiceStatus.DRAFT);
+      expect(result.pricingMode).toBe(InvoicePricingMode.FIXED_CRYPTO);
+      expect(result.amountPaid).toBe(BigInt(0));
+      expect(result.amountRefunded).toBe(BigInt(0));
+      expect(prismaMock.invoice.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          invoiceId: 1001,
+          paymentSlug: 'pay-abc123',
+          description: 'Payment for services',
+        }),
+      });
+    });
+
+    test('creates a FIXED_FIAT invoice with fiat pricing fields populated', async () => {
+      const fiatInvoice = {
+        ...baseInvoice,
+        pricingMode: InvoicePricingMode.FIXED_FIAT,
+        fiatCurrency: 'USD',
+        fiatAmount: BigInt(500_00),
+        fiatDecimals: 2,
+      };
+      prismaMock.invoice.create.mockResolvedValue(fiatInvoice);
+
+      const result = await prismaMock.invoice.create({
+        data: {
+          invoiceId: 1002,
+          paymentSlug: 'pay-def456',
+          description: 'USD-pegged invoice',
+          amount: BigInt(1_000_000),
+          token: 'CABC...TOKEN',
+          merchantId: 'merchant-uuid',
+          status: InvoiceStatus.PENDING,
+          pricingMode: InvoicePricingMode.FIXED_FIAT,
+          fiatCurrency: 'USD',
+          fiatAmount: BigInt(500_00),
+          fiatDecimals: 2,
+        },
+      });
+
+      expect(result.pricingMode).toBe(InvoicePricingMode.FIXED_FIAT);
+      expect(result.fiatCurrency).toBe('USD');
+      expect(result.fiatAmount).toBe(BigInt(500_00));
+      expect(result.fiatDecimals).toBe(2);
+    });
+
+    test('creates an invoice with an expiry date', async () => {
+      const expiresAt = new Date(mockDate.getTime() + 24 * 60 * 60 * 1000);
+      const expiringInvoice = { ...baseInvoice, expiresAt };
+      prismaMock.invoice.create.mockResolvedValue(expiringInvoice);
+
+      const result = await prismaMock.invoice.create({
+        data: {
+          ...baseInvoice,
+          expiresAt,
+        },
+      });
+
+      expect(result.expiresAt).toEqual(expiresAt);
+    });
+  });
+
+  describe('InvoiceStatus transitions', () => {
+    test.each([
+      [InvoiceStatus.PENDING],
+      [InvoiceStatus.PAID],
+      [InvoiceStatus.CANCELLED],
+      [InvoiceStatus.REFUNDED],
+      [InvoiceStatus.PARTIALLY_REFUNDED],
+      [InvoiceStatus.PARTIALLY_PAID],
+      [InvoiceStatus.DRAFT],
+    ])('accepts status %s', async (status) => {
+      prismaMock.invoice.update.mockResolvedValue({ ...baseInvoice, status });
+
+      const result = await prismaMock.invoice.update({
+        where: { id: 'invoice-uuid' },
+        data: { status },
+      });
+
+      expect(result.status).toBe(status);
+    });
+
+    test('records amountPaid and datePaid when status transitions to PAID', async () => {
+      const paidInvoice = {
+        ...baseInvoice,
+        status: InvoiceStatus.PAID,
+        amountPaid: BigInt(1_000_000),
+        datePaid: mockDate,
+      };
+      prismaMock.invoice.update.mockResolvedValue(paidInvoice);
+
+      const result = await prismaMock.invoice.update({
+        where: { id: 'invoice-uuid' },
+        data: {
+          status: InvoiceStatus.PAID,
+          amountPaid: BigInt(1_000_000),
+          datePaid: mockDate,
+        },
+      });
+
+      expect(result.status).toBe(InvoiceStatus.PAID);
+      expect(result.amountPaid).toBe(BigInt(1_000_000));
+      expect(result.datePaid).toEqual(mockDate);
+    });
+
+    test('records amountRefunded when status transitions to REFUNDED', async () => {
+      const refundedInvoice = {
+        ...baseInvoice,
+        status: InvoiceStatus.REFUNDED,
+        amountPaid: BigInt(1_000_000),
+        amountRefunded: BigInt(1_000_000),
+        datePaid: mockDate,
+      };
+      prismaMock.invoice.update.mockResolvedValue(refundedInvoice);
+
+      const result = await prismaMock.invoice.update({
+        where: { id: 'invoice-uuid' },
+        data: {
+          status: InvoiceStatus.REFUNDED,
+          amountRefunded: BigInt(1_000_000),
+        },
+      });
+
+      expect(result.status).toBe(InvoiceStatus.REFUNDED);
+      expect(result.amountRefunded).toBe(BigInt(1_000_000));
+    });
+
+    test('records partial amounts for PARTIALLY_PAID status', async () => {
+      const partialInvoice = {
+        ...baseInvoice,
+        status: InvoiceStatus.PARTIALLY_PAID,
+        amountPaid: BigInt(500_000),
+      };
+      prismaMock.invoice.update.mockResolvedValue(partialInvoice);
+
+      const result = await prismaMock.invoice.update({
+        where: { id: 'invoice-uuid' },
+        data: { status: InvoiceStatus.PARTIALLY_PAID, amountPaid: BigInt(500_000) },
+      });
+
+      expect(result.status).toBe(InvoiceStatus.PARTIALLY_PAID);
+      expect(result.amountPaid).toBe(BigInt(500_000));
+    });
+  });
+
+  describe('unique constraints', () => {
+    test('findUnique by invoiceId returns the invoice', async () => {
+      prismaMock.invoice.findUnique.mockResolvedValue(baseInvoice);
+
+      const result = await prismaMock.invoice.findUnique({ where: { invoiceId: 1001 } });
+
+      expect(result).toEqual(baseInvoice);
+      expect(prismaMock.invoice.findUnique).toHaveBeenCalledWith({
+        where: { invoiceId: 1001 },
+      });
+    });
+
+    test('findUnique by paymentSlug returns the invoice', async () => {
+      prismaMock.invoice.findUnique.mockResolvedValue(baseInvoice);
+
+      const result = await prismaMock.invoice.findUnique({ where: { paymentSlug: 'pay-abc123' } });
+
+      expect(result).toEqual(baseInvoice);
+    });
+
+    test('rejects duplicate paymentSlug with P2002', async () => {
+      const uniqueError = Object.assign(new Error('Unique constraint failed'), {
+        code: 'P2002',
+        meta: { target: ['paymentSlug'] },
+      });
+      prismaMock.invoice.create.mockRejectedValue(uniqueError);
+
+      await expect(
+        prismaMock.invoice.create({
+          data: { ...baseInvoice, id: 'other-uuid', invoiceId: 9999 },
+        }),
+      ).rejects.toMatchObject({ code: 'P2002', meta: { target: ['paymentSlug'] } });
+    });
+
+    test('rejects duplicate invoiceId with P2002', async () => {
+      const uniqueError = Object.assign(new Error('Unique constraint failed'), {
+        code: 'P2002',
+        meta: { target: ['invoiceId'] },
+      });
+      prismaMock.invoice.create.mockRejectedValue(uniqueError);
+
+      await expect(
+        prismaMock.invoice.create({
+          data: { ...baseInvoice, id: 'other-uuid', paymentSlug: 'pay-new' },
+        }),
+      ).rejects.toMatchObject({ code: 'P2002', meta: { target: ['invoiceId'] } });
+    });
+  });
+
+  describe('merchant relation', () => {
+    test('findUnique with merchant include returns nested merchant', async () => {
+      prismaMock.invoice.findUnique.mockResolvedValue({
+        ...baseInvoice,
+        merchant: baseMerchant,
+      });
+
+      const result = await prismaMock.invoice.findUnique({
+        where: { id: 'invoice-uuid' },
+        include: { merchant: true },
+      });
+
+      expect(result?.merchant).toMatchObject({ id: 'merchant-uuid' });
+    });
+  });
+});

--- a/tests/unit/subscription.schema.test.ts
+++ b/tests/unit/subscription.schema.test.ts
@@ -1,0 +1,222 @@
+import { mockReset } from 'jest-mock-extended';
+import { SubscriptionStatus } from '@prisma/client';
+
+const { default: prismaMock } = (await import('../../src/config/prisma.js')) as any;
+
+const mockDate = new Date('2026-06-24T10:00:00Z');
+
+const basePlan = {
+  id: 'plan-uuid',
+  planId: 101,
+  merchantId: 'merchant-uuid',
+  description: 'Monthly Pro Plan',
+  token: 'CABC...TOKEN',
+  amount: BigInt(10_000_000),
+  interval: 2_592_000, // 30 days in seconds
+  active: true,
+  createdAt: mockDate,
+  updatedAt: mockDate,
+};
+
+const baseSubscription = {
+  id: 'sub-uuid',
+  subscriptionId: 501,
+  planId: 'plan-uuid',
+  merchantId: 'merchant-uuid',
+  customer: 'GCUSTOMER123',
+  status: SubscriptionStatus.ACTIVE,
+  lastCharged: null,
+  createdAt: mockDate,
+  updatedAt: mockDate,
+};
+
+describe('SubscriptionPlan schema', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  describe('create', () => {
+    test('creates a plan with all required fields', async () => {
+      prismaMock.subscriptionPlan.create.mockResolvedValue(basePlan);
+
+      const result = await prismaMock.subscriptionPlan.create({
+        data: {
+          planId: 101,
+          merchantId: 'merchant-uuid',
+          description: 'Monthly Pro Plan',
+          token: 'CABC...TOKEN',
+          amount: BigInt(10_000_000),
+          interval: 2_592_000,
+        },
+      });
+
+      expect(result.planId).toBe(101);
+      expect(result.amount).toBe(BigInt(10_000_000));
+      expect(result.interval).toBe(2_592_000);
+      expect(result.active).toBe(true);
+      expect(prismaMock.subscriptionPlan.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          planId: 101,
+          description: 'Monthly Pro Plan',
+          interval: 2_592_000,
+        }),
+      });
+    });
+
+    test('creates a plan in inactive state', async () => {
+      prismaMock.subscriptionPlan.create.mockResolvedValue({ ...basePlan, active: false });
+
+      const result = await prismaMock.subscriptionPlan.create({
+        data: { ...basePlan, active: false },
+      });
+
+      expect(result.active).toBe(false);
+    });
+  });
+
+  describe('unique constraints', () => {
+    test('findUnique by planId returns the plan', async () => {
+      prismaMock.subscriptionPlan.findUnique.mockResolvedValue(basePlan);
+
+      const result = await prismaMock.subscriptionPlan.findUnique({ where: { planId: 101 } });
+
+      expect(result).toEqual(basePlan);
+    });
+
+    test('rejects duplicate planId with P2002', async () => {
+      const uniqueError = Object.assign(new Error('Unique constraint failed'), {
+        code: 'P2002',
+        meta: { target: ['planId'] },
+      });
+      prismaMock.subscriptionPlan.create.mockRejectedValue(uniqueError);
+
+      await expect(
+        prismaMock.subscriptionPlan.create({ data: { ...basePlan, id: 'plan-uuid-2' } }),
+      ).rejects.toMatchObject({ code: 'P2002', meta: { target: ['planId'] } });
+    });
+  });
+
+  describe('deactivation', () => {
+    test('update sets active to false', async () => {
+      prismaMock.subscriptionPlan.update.mockResolvedValue({ ...basePlan, active: false });
+
+      const result = await prismaMock.subscriptionPlan.update({
+        where: { id: 'plan-uuid' },
+        data: { active: false },
+      });
+
+      expect(result.active).toBe(false);
+    });
+  });
+});
+
+describe('Subscription schema', () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  describe('create', () => {
+    test('creates an ACTIVE subscription with lastCharged null initially', async () => {
+      prismaMock.subscription.create.mockResolvedValue(baseSubscription);
+
+      const result = await prismaMock.subscription.create({
+        data: {
+          subscriptionId: 501,
+          planId: 'plan-uuid',
+          merchantId: 'merchant-uuid',
+          customer: 'GCUSTOMER123',
+          status: SubscriptionStatus.ACTIVE,
+        },
+      });
+
+      expect(result.status).toBe(SubscriptionStatus.ACTIVE);
+      expect(result.lastCharged).toBeNull();
+      expect(result.customer).toBe('GCUSTOMER123');
+    });
+  });
+
+  describe('SubscriptionStatus transitions', () => {
+    test('records lastCharged when a billing cycle runs', async () => {
+      const chargedAt = new Date('2026-07-24T10:00:00Z');
+      prismaMock.subscription.update.mockResolvedValue({
+        ...baseSubscription,
+        lastCharged: chargedAt,
+      });
+
+      const result = await prismaMock.subscription.update({
+        where: { id: 'sub-uuid' },
+        data: { lastCharged: chargedAt },
+      });
+
+      expect(result.lastCharged).toEqual(chargedAt);
+    });
+
+    test('transitions to CANCELLED status', async () => {
+      prismaMock.subscription.update.mockResolvedValue({
+        ...baseSubscription,
+        status: SubscriptionStatus.CANCELLED,
+      });
+
+      const result = await prismaMock.subscription.update({
+        where: { id: 'sub-uuid' },
+        data: { status: SubscriptionStatus.CANCELLED },
+      });
+
+      expect(result.status).toBe(SubscriptionStatus.CANCELLED);
+    });
+
+    test.each([
+      [SubscriptionStatus.ACTIVE],
+      [SubscriptionStatus.CANCELLED],
+    ])('accepts status %s', async (status) => {
+      prismaMock.subscription.update.mockResolvedValue({ ...baseSubscription, status });
+
+      const result = await prismaMock.subscription.update({
+        where: { id: 'sub-uuid' },
+        data: { status },
+      });
+
+      expect(result.status).toBe(status);
+    });
+  });
+
+  describe('unique constraints', () => {
+    test('findUnique by subscriptionId returns the subscription', async () => {
+      prismaMock.subscription.findUnique.mockResolvedValue(baseSubscription);
+
+      const result = await prismaMock.subscription.findUnique({
+        where: { subscriptionId: 501 },
+      });
+
+      expect(result).toEqual(baseSubscription);
+    });
+
+    test('rejects duplicate subscriptionId with P2002', async () => {
+      const uniqueError = Object.assign(new Error('Unique constraint failed'), {
+        code: 'P2002',
+        meta: { target: ['subscriptionId'] },
+      });
+      prismaMock.subscription.create.mockRejectedValue(uniqueError);
+
+      await expect(
+        prismaMock.subscription.create({ data: { ...baseSubscription, id: 'sub-uuid-2' } }),
+      ).rejects.toMatchObject({ code: 'P2002', meta: { target: ['subscriptionId'] } });
+    });
+  });
+
+  describe('plan relation', () => {
+    test('findUnique with plan include returns nested plan', async () => {
+      prismaMock.subscription.findUnique.mockResolvedValue({
+        ...baseSubscription,
+        plan: basePlan,
+      });
+
+      const result = await prismaMock.subscription.findUnique({
+        where: { id: 'sub-uuid' },
+        include: { plan: true },
+      });
+
+      expect(result?.plan).toMatchObject({ planId: 101, interval: 2_592_000 });
+    });
+  });
+});

--- a/tests/unit/subscription.schema.test.ts
+++ b/tests/unit/subscription.schema.test.ts
@@ -1,5 +1,12 @@
 import { mockReset } from 'jest-mock-extended';
-import { SubscriptionStatus } from '@prisma/client';
+
+// Local mirror of the Prisma enum — never import runtime values from
+// @prisma/client in tests; the generated client may not exist in CI.
+const SubscriptionStatus = {
+  ACTIVE: 'ACTIVE',
+  CANCELLED: 'CANCELLED',
+} as const;
+type SubscriptionStatus = (typeof SubscriptionStatus)[keyof typeof SubscriptionStatus];
 
 const { default: prismaMock } = (await import('../../src/config/prisma.js')) as any;
 


### PR DESCRIPTION
## Summary

- **`Merchant`** — adds `address @unique`; full profile fields already present are retained
- **`InvoiceStatus` enum** — renames `Status` → `InvoiceStatus` and adds `EXPIRED` to match the smart contract's status naming
- **`Invoice`** — adds `paymentSlug String @unique` for payment-link routing
- **`ApiKey`** — new model; stores `keyHash` only (SHA-256 of the raw key), never plaintext; supports optional `name`, `expiresAt`, and soft-revocation via `revokedAt`
- **`RefreshToken`** — renames `MerchantSession` to `RefreshToken`; table purpose is now explicit
- **`Admin`** — retained with `address @unique` added; admin auth is a separate concern outside merchant flows
- **Migration** — old draft migration replaced with a single clean `20260623000000_init` baseline generated via `prisma migrate diff --from-empty`

## How to apply on a fresh database

```bash
DATABASE_URL=<your-url> npx prisma migrate reset --force
DATABASE_URL=<your-url> npx prisma migrate dev
```

## Test plan
 - [x] prisma validate passes — confirmed ✅
 - [x]  prisma generate completes without errors — confirmed ✅
 - [x] tsc --noEmit reports zero errors in src/ — confirmed ✅
 - [x] All 22 unit tests pass (npm test -- --testPathPatterns=unit) — confirmed ✅ 
 - [x] prisma migrate dev runs without error on a fresh PostgreSQL database


Closes #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/expanded support for refresh tokens, API keys, subscriptions, transactions, token analytics, and bridge payments.
  * Redefined invoicing with new invoice statuses, pricing modes, fiat fields, payment/refund tracking, and globally unique payment slugs.
  * Expanded merchant profile/auth relationships (including webhook/account fields).
* **Bug Fixes**
  * Merchant authentication now uses refresh tokens to resolve the active session.
  * Wallet registration status now reflects the merchant’s `registered` flag.
  * Updated invoice payer contact field naming and status typing/validation to stay consistent.
* **Tests**
  * Updated auth/invoice/registration fixtures and added unit coverage for analytics schema behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->